### PR TITLE
Fix entering August and September roast dates.

### DIFF
--- a/DYE.tcl
+++ b/DYE.tcl
@@ -1970,7 +1970,7 @@ proc ::dui::pages::DYE::compute_days_offroast { {reformat 1} } {
 		}
 	}
 	
-	if { $month ne "" && ![string is integer $month] } {
+	if { $month ne "" && ![string is integer [scan $month %d]] } {
 		set month [lsearch -nocase {jan feb mar apr may jun jul aug sep oct nov dec} [string range $month 0 2]]
 		if { $month == -1 } {
 			set month {}


### PR DESCRIPTION
When `string is integer` sees a leading zero, it assumes the input is octal. If it's an invalid octal number but still a valid integer, it returns `false` anyway. There is no way to change that, see https://wiki.tcl-lang.org/page/string+is#719e42c64af45603452487f7d0b90e894001a9a9e3ec7ceaf8234cd0212ddf3f

01 to 07 are valid octal numbers, but 08 and 09 are not. If you enter an August or September roast date, the "is integer" check fails. Thus, the logic ends up setting the roast month to an empty string by accident, resulting in it ultimately being force-set to the current month.

Fixes #5